### PR TITLE
parent_parserのadd_helpの値に関係なくparserを統合

### DIFF
--- a/src/example.py
+++ b/src/example.py
@@ -75,8 +75,7 @@ class Example(template.Main):        # templateを継承
 
     def make_calc_parser(self):
         parser = ArgumentParser(
-            formatter_class=ArgumentDefaultsHelpFormatter,
-            add_help=False
+            formatter_class=ArgumentDefaultsHelpFormatter
         )
         g = parser.add_argument_group('calc arguments')
         x_help = 'the first argument of divide operation'
@@ -98,8 +97,7 @@ class Example(template.Main):        # templateを継承
 
     def make_io_parser(self):
         parser = ArgumentParser(
-            formatter_class=ArgumentDefaultsHelpFormatter,
-            add_help=False
+            formatter_class=ArgumentDefaultsHelpFormatter
         )
         g = parser.add_argument_group('I/O settings')
         output_help = 'output filename'

--- a/src/exp_wrapper/template.py
+++ b/src/exp_wrapper/template.py
@@ -151,6 +151,24 @@ class Main(object):
         description = main_parser.description
         epilog = main_parser.epilog
         version = main_parser.version
+
+        def remove_options(parser, options):
+            for option in options:
+                for action in parser._actions:
+                    action_dict = vars(action)
+                    if 'option_strings' in action_dict:
+                        opt_strs = action_dict['option_strings']
+                        if option in opt_strs:
+                            parser._handle_conflict_resolve(
+                                None, [(option, action)]
+                            )
+                            break
+
+        for parser in parents:
+            if parser.add_help:
+                remove_options(parser, ['--help', '-h'])
+                parser.add_help = False
+
         aggregated_parser = argparse.ArgumentParser(
             prog=prog,
             description=description,


### PR DESCRIPTION
 # 目標
 parent_parserのadd_helpの値に関係なくparserを統合する。
 そのためにはparents内のhelpオプションを消去する必要がある。
 # TODO
 - [x] parentsのhelpオプションの消去